### PR TITLE
Removed pom repository tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,4 @@
 		</plugins>
 	</build>
 
-	<repositories>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-		</repository>
-		<repository>
-			<id>maven-sonatype</id>
-			<url>https://search.maven.org/</url>
-		</repository>
-	</repositories>
-
 </project>


### PR DESCRIPTION
Builds in the cloud continued to fail due to an unparseable BOM
from dependencies pulled from the repositories in <repositories>.
Removing them should allow for `mvn clean install` to complete
normall